### PR TITLE
Remover carpeta .vscode del repositorio

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule ".vscode"]
-	path = .vscode
-	url = https://github.com/ipqa-research/vscode-fortran.git


### PR DESCRIPTION
El repo tenía las configuraciones de `vscode` como un submódulo. Esta funcionalidad ya no la manejamos así, ya que generaba conflictos trabajando entre ramas.

Actualmente un usuario interesado en trabajar con `Forcha` debería de hacer:

```bash
# Clonar el repositorio de Forcha en la carpeta de sus proyectos 
# (la carpeta que utiliza `fortran_project`)
git clone https://github.com/ipqa-research/Forcha ~/codes/Forcha

# Clonar las configuraciones de vscode dentro de esa carpeta
git clone https://github.com/ipqa-research/vscode-fortran ~/codes/Forcha/.vscode
```